### PR TITLE
fix bug:when bf matcher return m_keypoint less that 4, findhomography will raise error

### DIFF
--- a/kp2d/evaluation/descriptor_evaluation.py
+++ b/kp2d/evaluation/descriptor_evaluation.py
@@ -211,6 +211,9 @@ def compute_homography(data, keep_k_points=1000):
     matches_idx = np.array([m.trainIdx for m in matches])
     m_warped_keypoints = warped_keypoints[matches_idx, :]
 
+    if m_keypoints.shape[0] <4 or m_warped_keypoints.shape[0] <4:
+        return 0,0,0
+
     # Estimate the homography between the matches using RANSAC
     H, _ = cv2.findHomography(m_keypoints, m_warped_keypoints, cv2.RANSAC, 3, maxIters=5000)
 


### PR DESCRIPTION
when on the epoch 0, the keypoints get from HPatch dataset after bf matcher, the number of match keypoints may less 4,findhomography will raise a error....

In My train:
on epoch 0, when eval `HPatches/i_bridger/1.ppm` and `HPatches/i_bridger/6.ppm`,the keypoints number after bf matcher will become 2,can not get a homography matrix