### PR TITLE
fix bug: when batch size is 1, squeeze will squeeze the the axis of batch

### DIFF
--- a/kp2d/evaluation/descriptor_evaluation.py
+++ b/kp2d/evaluation/descriptor_evaluation.py
@@ -211,6 +211,9 @@ def compute_homography(data, keep_k_points=1000):
     matches_idx = np.array([m.trainIdx for m in matches])
     m_warped_keypoints = warped_keypoints[matches_idx, :]
 
+    if m_keypoints.shape[0] <4 or m_warped_keypoints.shape[0] <4:
+        return 0,0,0
+
     # Estimate the homography between the matches using RANSAC
     H, _ = cv2.findHomography(m_keypoints, m_warped_keypoints, cv2.RANSAC, 3, maxIters=5000)
 

--- a/kp2d/models/KeypointNetwithIOLoss.py
+++ b/kp2d/models/KeypointNetwithIOLoss.py
@@ -324,8 +324,8 @@ class KeypointNetwithIOLoss(torch.nn.Module):
                 target_uv_norm_topk = target_uv_norm[top_k_mask2].view(B, self.top_k2, 2)
                 source_uv_warped_norm_topk = source_uv_warped_norm[top_k_mask1].view(B, self.top_k2, 2)
 
-                source_feat_topk = torch.nn.functional.grid_sample(source_feat, source_uv_norm_topk.unsqueeze(1), align_corners=True).squeeze()
-                target_feat_topk = torch.nn.functional.grid_sample(target_feat, target_uv_norm_topk.unsqueeze(1), align_corners=True).squeeze()
+                source_feat_topk = torch.nn.functional.grid_sample(source_feat, source_uv_norm_topk.unsqueeze(1), align_corners=True).squeeze(2)
+                target_feat_topk = torch.nn.functional.grid_sample(target_feat, target_uv_norm_topk.unsqueeze(1), align_corners=True).squeeze(2)
 
                 source_feat_topk = source_feat_topk.div(torch.norm(source_feat_topk, p=2, dim=1).unsqueeze(1))
                 target_feat_topk = target_feat_topk.div(torch.norm(target_feat_topk, p=2, dim=1).unsqueeze(1))
@@ -355,6 +355,8 @@ class KeypointNetwithIOLoss(torch.nn.Module):
 
                 if inlier_mask.sum() > 10:
 
+                    if inlier_pred.shape != inlier_gt.shape:
+                        inlier_pred = inlier_pred.unsqueeze(0)
                     io_loss = torch.nn.functional.mse_loss(inlier_pred, inlier_gt)
                     loss_2d += self.keypoint_loss_weight * io_loss
 


### PR DESCRIPTION
fix bug: when batch size is 1, squeeze will squeeze the the axis of batch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/kp2d/14)
<!-- Reviewable:end -->
